### PR TITLE
Update growl dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 # Pomodoro
 
-This is a basic CLI app that allows you to do pomodoro''s  in the command line. When the pomodoro is complete it will
-send a growl message
+This is a basic CLI app that allows you to do pomodoro''s  in the command line. When the pomodoro is complete it will send a growl message
+
+## Notofication center
+
+[node-growl](https://github.com/visionmedia/node-growl) supports Notification center in OS X 10.8. Install [terminal-notifier](https://github.com/alloy/terminal-notifier) to enable:
+
+  	$ sudo gem install terminal-notifier

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   , "keywords": ["pomodoro", "cli"]
   , "author": "David Burns"
   , "dependencies": {
-      "growl": "1.5.0"
+      "growl": "1.6.1"
       , "nomnom":"1.5.1"
     }
   , "repository": {


### PR DESCRIPTION
[node-growl](https://github.com/visionmedia/node-growl) has support for Notification center.
